### PR TITLE
Avoid async geary writes

### DIFF
--- a/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/ChattyChannel.kt
+++ b/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/ChattyChannel.kt
@@ -4,14 +4,12 @@ import com.mineinabyss.chatty.components.ChannelType
 import com.mineinabyss.chatty.components.SpyOnChannels
 import com.mineinabyss.chatty.queries.SpyingPlayers
 import com.mineinabyss.geary.papermc.tracking.entities.toGeary
-import com.mineinabyss.idofront.serialization.ColorSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import net.kyori.adventure.audience.Audience
 import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.format.TextColor
 import org.bukkit.Bukkit
-import org.bukkit.Color
 import org.bukkit.entity.Player
 
 @Serializable
@@ -25,14 +23,14 @@ data class ChattyChannel(
     val isDefaultChannel: Boolean = false,
     val isStaffChannel: Boolean = false,
     val format: String = "",
-    @Serializable(with=ColorSerializer::class)
-    @SerialName("messageColor") val _messageColor: Color = Color.WHITE,
+    @SerialName("messageColor") val _messageColor: String = "white",
     val channelRadius: Int = 0,
     val channelAliases: List<String> = listOf(),
 ) {
     val key by lazy { chatty.config.channels.entries.first { it.value == this }.key }
     val messageColor: TextColor
-        get() = TextColor.color(_messageColor.asRGB())
+        get() = TextColor.fromHexString(_messageColor) ?: NamedTextColor.NAMES.value(_messageColor)
+        ?: NamedTextColor.WHITE
 
 
     fun getAudience(player: Player): Collection<Audience> {

--- a/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/ChattyChannel.kt
+++ b/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/ChattyChannel.kt
@@ -4,12 +4,14 @@ import com.mineinabyss.chatty.components.ChannelType
 import com.mineinabyss.chatty.components.SpyOnChannels
 import com.mineinabyss.chatty.queries.SpyingPlayers
 import com.mineinabyss.geary.papermc.tracking.entities.toGeary
+import com.mineinabyss.idofront.serialization.ColorSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import net.kyori.adventure.audience.Audience
 import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.format.TextColor
 import org.bukkit.Bukkit
+import org.bukkit.Color
 import org.bukkit.entity.Player
 
 @Serializable
@@ -23,14 +25,14 @@ data class ChattyChannel(
     val isDefaultChannel: Boolean = false,
     val isStaffChannel: Boolean = false,
     val format: String = "",
-    @SerialName("messageColor") val _messageColor: String = "white",
+    @Serializable(with=ColorSerializer::class)
+    @SerialName("messageColor") val _messageColor: Color = Color.WHITE,
     val channelRadius: Int = 0,
     val channelAliases: List<String> = listOf(),
 ) {
     val key by lazy { chatty.config.channels.entries.first { it.value == this }.key }
     val messageColor: TextColor
-        get() = TextColor.fromHexString(_messageColor) ?: NamedTextColor.NAMES.value(_messageColor)
-        ?: NamedTextColor.WHITE
+        get() = TextColor.color(_messageColor.asRGB())
 
 
     fun getAudience(player: Player): Collection<Audience> {

--- a/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/ChattyChannel.kt
+++ b/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/ChattyChannel.kt
@@ -1,0 +1,62 @@
+package com.mineinabyss.chatty
+
+import com.mineinabyss.chatty.components.ChannelType
+import com.mineinabyss.chatty.components.SpyOnChannels
+import com.mineinabyss.chatty.queries.SpyingPlayers
+import com.mineinabyss.geary.papermc.tracking.entities.toGeary
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import net.kyori.adventure.audience.Audience
+import net.kyori.adventure.text.format.NamedTextColor
+import net.kyori.adventure.text.format.TextColor
+import org.bukkit.Bukkit
+import org.bukkit.entity.Player
+
+@Serializable
+data class ChattyChannel(
+    val channelType: ChannelType,
+    val permission: String = "",
+    val logToConsole: Boolean = true,
+    val simpleConsoleMessages: Boolean = false,
+    val proxy: Boolean = false,
+    val discordsrv: Boolean = true,
+    val isDefaultChannel: Boolean = false,
+    val isStaffChannel: Boolean = false,
+    val format: String = "",
+    @SerialName("messageColor") val _messageColor: String = "white",
+    val channelRadius: Int = 0,
+    val channelAliases: List<String> = listOf(),
+) {
+    val key by lazy { chatty.config.channels.entries.first { it.value == this }.key }
+    val messageColor: TextColor
+        get() = TextColor.fromHexString(_messageColor) ?: NamedTextColor.NAMES.value(_messageColor)
+        ?: NamedTextColor.WHITE
+
+
+    fun getAudience(player: Player): Collection<Audience> {
+        val onlinePlayers by lazy { Bukkit.getOnlinePlayers() }
+        val audiences = mutableSetOf<Audience>()
+
+        when (channelType) {
+            ChannelType.GLOBAL -> audiences.addAll(onlinePlayers)
+            ChannelType.RADIUS -> {
+                if (channelRadius <= 0) audiences.addAll(onlinePlayers)
+                else audiences.addAll(player.world.players.filter { p ->
+                    player.location.distanceSquared(p.location) <= (channelRadius * channelRadius)
+                })
+            }
+
+            ChannelType.PERMISSION -> audiences.addAll(onlinePlayers.filter { p -> p.hasPermission(permission) })
+            // Intended for Guilds etc., want to consider finding a non-permission way for this
+            ChannelType.PRIVATE -> audiences.add(player)
+        }
+
+        // Add spying players
+        val spies = SpyingPlayers().run {
+            toList { query -> query.player.takeIf { query.spying.channels.contains(key) } }.filterNotNull()
+        }
+        audiences.addAll(spies)
+
+        return audiences
+    }
+}

--- a/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/ChattyChannel.kt
+++ b/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/ChattyChannel.kt
@@ -52,7 +52,7 @@ data class ChattyChannel(
         }
 
         // Add spying players
-        val spies = SpyingPlayers().run {
+        val spies = chatty.spyingPlayers.run {
             toList { query -> query.player.takeIf { query.spying.channels.contains(key) } }.filterNotNull()
         }
         audiences.addAll(spies)

--- a/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/ChattyCommands.kt
+++ b/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/ChattyCommands.kt
@@ -266,8 +266,9 @@ class ChattyCommands : IdofrontCommandExecutor(), TabCompleter {
 
             arguments.isEmpty() -> swapChannelCommand(channel.value)
             else -> {
-                toGeary().setPersisting(chattyData.copy(channelId = channel.key, lastChannelUsedId = channel.key))
-                chatty.plugin.launch(chatty.plugin.asyncDispatcher) {
+                val gearyPlayer = toGeary()
+                gearyPlayer.setPersisting(chattyData.copy(channelId = channel.key, lastChannelUsedId = channel.key))
+                runCatching {
                     GenericChattyDecorateEvent(this@shortcutCommand, arguments.toSentence().miniMsg()).call {
                         GenericChattyChatEvent(
                             this@shortcutCommand,
@@ -275,7 +276,7 @@ class ChattyCommands : IdofrontCommandExecutor(), TabCompleter {
                         ).callEvent()
                     }
                 }
-                toGeary().setPersisting(chattyData.copy(channelId = currentChannel))
+                gearyPlayer.setPersisting(chattyData.copy(channelId = currentChannel))
             }
         }
     }

--- a/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/ChattyCommands.kt
+++ b/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/ChattyCommands.kt
@@ -9,6 +9,7 @@ import com.mineinabyss.chatty.helpers.*
 import com.mineinabyss.geary.papermc.tracking.entities.toGeary
 import com.mineinabyss.idofront.commands.arguments.stringArg
 import com.mineinabyss.idofront.commands.execution.IdofrontCommandExecutor
+import com.mineinabyss.idofront.commands.extensions.actions.ensureSenderIsPlayer
 import com.mineinabyss.idofront.commands.extensions.actions.playerAction
 import com.mineinabyss.idofront.entities.toPlayer
 import com.mineinabyss.idofront.events.call
@@ -180,13 +181,16 @@ class ChattyCommands : IdofrontCommandExecutor(), TabCompleter {
             }
         }
         ("message" / "msg")(desc = "Private message another player") {
-            val otherPlayer by stringArg()
-            playerAction {
-                player.handleSendingPrivateMessage(otherPlayer.toPlayer() ?: return@playerAction, arguments, false)
+            ensureSenderIsPlayer()
+            val player by stringArg()
+            action {
+                (sender as? Player)?.handleSendingPrivateMessage(player.toPlayer() ?: return@action, arguments, false)
             }
         }
         ("reply" / "r")(desc = "Reply to your previous private message") {
-            playerAction {
+            ensureSenderIsPlayer()
+            action {
+                val player = sender as? Player ?: return@action
                 player.toGeary().get<ChannelData>()?.lastMessager?.toPlayer()
                     ?.let { player.handleSendingPrivateMessage(it, arguments, true) }
                     ?: player.sendFormattedMessage(chatty.messages.privateMessages.emptyReply)

--- a/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/ChattyCommands.kt
+++ b/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/ChattyCommands.kt
@@ -166,18 +166,21 @@ class ChattyCommands : IdofrontCommandExecutor(), TabCompleter {
                 }
         }
         ("global" / "g") {
-            playerAction {
-                player.shortcutCommand(getGlobalChat(), arguments)
+            ensureSenderIsPlayer()
+            action {
+                (sender as? Player)?.shortcutCommand(getGlobalChat(), arguments)
             }
         }
         ("local" / "l") {
-            playerAction {
-                player.shortcutCommand(getRadiusChannel(), arguments)
+            ensureSenderIsPlayer()
+            action {
+                (sender as? Player)?.shortcutCommand(getRadiusChannel(), arguments)
             }
         }
         ("admin" / "a") {
-            playerAction {
-                player.shortcutCommand(getAdminChannel(), arguments)
+            ensureSenderIsPlayer()
+            action {
+                (sender as? Player)?.shortcutCommand(getAdminChannel(), arguments)
             }
         }
         ("message" / "msg")(desc = "Private message another player") {
@@ -241,7 +244,11 @@ class ChattyCommands : IdofrontCommandExecutor(), TabCompleter {
                     else -> emptyList()
                 }
             }
-            "message", "msg" -> onlinePlayers.filter { s -> s.startsWith(args[0], true) }.take(25)
+            "message", "msg" ->
+                when (args.size) {
+                    0, 1 -> onlinePlayers.filter { s -> s.startsWith(args[0], true) }.take(25)
+                    else -> emptyList()
+                }
             else -> emptyList()
         }
     }

--- a/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/ChattyCommands.kt
+++ b/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/ChattyCommands.kt
@@ -206,41 +206,44 @@ class ChattyCommands : IdofrontCommandExecutor(), TabCompleter {
     ): List<String> {
         val onlinePlayers = Bukkit.getOnlinePlayers().map { it.name }
         val otherPrefix = chatty.config.nicknames.nickNameOtherPrefix
-        return if (command.name == "chatty") {
-            when (args.size) {
-                1 -> listOf(
-                    "message",
-                    "ping",
-                    "reload",
-                    "channels",
-                    "nickname",
-                    "spy",
-                    "commandspy"
-                ).filter { s -> s.startsWith(args[0]) }
+        return when (command.name) {
+            "chatty" -> {
+                when (args.size) {
+                    1 -> listOf(
+                        "message",
+                        "ping",
+                        "reload",
+                        "channels",
+                        "nickname",
+                        "spy",
+                        "commandspy"
+                    ).filter { s -> s.startsWith(args[0]) }
 
-                2 -> when (args[0]) {
-                    "ping" -> listOf("toggle", "sound").filter { s -> s.startsWith(args[1]) }
-                    "message", "msg" -> onlinePlayers.filter { s -> s.startsWith(args[1], true) }
-                    "spy" ->
-                        chatty.config.channels.entries.filter { s ->
-                            s.key.startsWith(args[1], true) && s.value.channelType != ChannelType.GLOBAL
-                        }.map { it.key }
+                    2 -> when (args[0]) {
+                        "ping" -> listOf("toggle", "sound").filter { s -> s.startsWith(args[1]) }
+                        "spy" ->
+                            chatty.config.channels.entries.filter { s ->
+                                s.key.startsWith(args[1], true) && s.value.channelType != ChannelType.GLOBAL
+                            }.map { it.key }
 
-                    else -> emptyList()
-                }
+                        else -> emptyList()
+                    }
 
-                3 -> when {
-                    args[1] == "sound" -> getAlternativePingSounds.filter { s -> s.startsWith(args[2], true) }
-                    args[1].startsWith(otherPrefix) -> onlinePlayers.filter { s ->
-                        s.replace(otherPrefix.toString(), "").startsWith(args[2], true)
+                    3 -> when {
+                        args[1] == "sound" -> getAlternativePingSounds.filter { s -> s.startsWith(args[2], true) }
+                        args[1].startsWith(otherPrefix) -> onlinePlayers.filter { s ->
+                            s.replace(otherPrefix.toString(), "").startsWith(args[2], true)
+                        }
+
+                        else -> emptyList()
                     }
 
                     else -> emptyList()
                 }
-
-                else -> emptyList()
             }
-        } else emptyList()
+            "message", "msg" -> onlinePlayers.filter { s -> s.startsWith(args[0], true) }.take(25)
+            else -> emptyList()
+        }
     }
 
     private fun Player.shortcutCommand(

--- a/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/ChattyCommands.kt
+++ b/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/ChattyCommands.kt
@@ -9,7 +9,6 @@ import com.mineinabyss.chatty.helpers.*
 import com.mineinabyss.geary.papermc.tracking.entities.toGeary
 import com.mineinabyss.idofront.commands.arguments.stringArg
 import com.mineinabyss.idofront.commands.execution.IdofrontCommandExecutor
-import com.mineinabyss.idofront.commands.extensions.actions.ensureSenderIsPlayer
 import com.mineinabyss.idofront.commands.extensions.actions.playerAction
 import com.mineinabyss.idofront.entities.toPlayer
 import com.mineinabyss.idofront.events.call
@@ -23,8 +22,6 @@ import org.bukkit.command.Command
 import org.bukkit.command.CommandSender
 import org.bukkit.command.TabCompleter
 import org.bukkit.entity.Player
-import kotlin.collections.component1
-import kotlin.collections.component2
 import kotlin.collections.set
 
 class ChattyCommands : IdofrontCommandExecutor(), TabCompleter {
@@ -35,46 +32,23 @@ class ChattyCommands : IdofrontCommandExecutor(), TabCompleter {
                     chatty.plugin.createChattyContext()
                     sender.sendConsoleMessage("<green>Chatty has been reloaded!")
                 }
-                // chatty.config.reload() is a thing but does not regen or remove stuff so
-//                    chatty.config.reload()
-//                    chatty.messages.reload()
-//                    chatty.emoteFixer.reload()
-            }
-            ("message" / "msg")(desc = "Private message another player") {
-                ensureSenderIsPlayer()
-                val player by stringArg()
-                action {
-                    (sender as? Player)?.handleSendingPrivateMessage(
-                        player.toPlayer() ?: return@action,
-                        arguments,
-                        false
-                    )
-                }
-            }
-            ("reply" / "r")(desc = "Reply to your previous private message") {
-                ensureSenderIsPlayer()
-                action {
-                    val player = sender as? Player ?: return@action
-                    player.chattyData.lastMessager?.toPlayer()?.let { player.handleSendingPrivateMessage(it, arguments, true) }
-                        ?: player.sendFormattedMessage(chatty.messages.privateMessages.emptyReply)
-                }
             }
             "ping"(desc = "Commands related to the chat-ping feature.") {
                 "toggle"(desc = "Toggle the ping sound.") {
-                    ensureSenderIsPlayer()
-                    action {
-                        val player = sender as? Player ?: return@action
-                        player.toGeary().setPersisting(player.chattyData.apply { ChannelData(channelId, lastChannelUsed, !disablePingSound, pingSound, lastMessager) })
+                    playerAction {
+                        val gearyPlayer = player.toGeary()
+                        val oldData = gearyPlayer.get<ChannelData>() ?: return@playerAction
+                        gearyPlayer.setPersisting(oldData.copy(disablePingSound = !oldData.disablePingSound))
                         player.sendFormattedMessage(chatty.messages.ping.toggledPingSound)
                     }
                 }
                 "sound"(desc = "Change your pingsound") {
                     val soundName by stringArg()
-                    ensureSenderIsPlayer()
-                    action {
-                        val player = sender as? Player ?: return@action
+                    playerAction {
+                        val gearyPlayer = player.toGeary()
+                        val oldData = gearyPlayer.get<ChannelData>() ?: return@playerAction
                         if (soundName in getAlternativePingSounds) {
-                            player.toGeary().setPersisting(player.chattyData.apply { ChannelData(channelId, lastChannelUsed, !disablePingSound, soundName, lastMessager) })
+                            gearyPlayer.setPersisting(oldData.copy(pingSound = soundName))
                             player.sendFormattedMessage(chatty.messages.ping.changedPingSound)
                         } else player.sendFormattedMessage(chatty.messages.ping.invalidPingSound)
                     }
@@ -87,21 +61,19 @@ class ChattyCommands : IdofrontCommandExecutor(), TabCompleter {
                 }
             }
             ("nickname" / "nick") {
-                action {
+                playerAction {
                     val nickMessage = chatty.messages.nicknames
                     val nick = arguments.toSentence()
-                    val player = sender as? Player
-                    val bypassFormatPerm = player?.hasPermission(ChattyPermissions.NICKNAME_OTHERS) == true
+                    val bypassFormatPerm = player.hasPermission(ChattyPermissions.NICKNAME_OTHERS)
 
                     when {
-                        player is Player && !player.hasPermission(ChattyPermissions.NICKNAME) ->
+                        !player.hasPermission(ChattyPermissions.NICKNAME) ->
                             player.sendFormattedMessage(nickMessage.selfDenied)
 
                         arguments.isEmpty() -> {
                             // Removes players displayname or sends error if sender is console
-                            player?.chattyNickname = null
-                            player?.sendFormattedMessage(nickMessage.selfEmpty)
-                                ?: sender.sendConsoleMessage(nickMessage.consoleNicknameSelf)
+                            player.chattyNickname = null
+                            player.sendFormattedMessage(nickMessage.selfEmpty)
                         }
 
                         arguments.first().startsWith(chatty.config.nicknames.nickNameOtherPrefix) -> {
@@ -109,34 +81,34 @@ class ChattyCommands : IdofrontCommandExecutor(), TabCompleter {
                             val otherNick = nick.removePlayerToNickFromString()
 
                             when {
-                                player?.hasPermission(ChattyPermissions.NICKNAME_OTHERS) == false ->
+                                !player.hasPermission(ChattyPermissions.NICKNAME_OTHERS) ->
                                     player.sendFormattedMessage(nickMessage.otherDenied, otherPlayer)
 
                                 otherPlayer == null || otherPlayer !in Bukkit.getOnlinePlayers() ->
-                                    player?.sendFormattedMessage(nickMessage.invalidPlayer, otherPlayer)
+                                    player.sendFormattedMessage(nickMessage.invalidPlayer, otherPlayer)
 
                                 otherNick.isEmpty() -> {
                                     otherPlayer.chattyNickname = null
                                     otherPlayer.sendFormattedMessage(nickMessage.selfEmpty)
-                                    player?.sendFormattedMessage(nickMessage.otherEmpty, otherPlayer)
+                                    player.sendFormattedMessage(nickMessage.otherEmpty, otherPlayer)
                                 }
 
                                 !bypassFormatPerm && !otherNick.verifyNickLength() ->
-                                    player?.sendFormattedMessage(nickMessage.tooLong)
+                                    player.sendFormattedMessage(nickMessage.tooLong)
 
                                 otherNick.isNotEmpty() -> {
                                     otherPlayer.chattyNickname = otherNick
-                                    player?.sendFormattedMessage(nickMessage.otherSuccess, otherPlayer)
+                                    player.sendFormattedMessage(nickMessage.otherSuccess, otherPlayer)
                                 }
                             }
                         }
 
                         else -> {
                             if (!bypassFormatPerm && !nick.verifyNickLength()) {
-                                player?.sendFormattedMessage(nickMessage.tooLong)
+                                player.sendFormattedMessage(nickMessage.tooLong)
                             } else {
-                                player?.chattyNickname = nick
-                                player?.sendFormattedMessage(nickMessage.selfSuccess)
+                                player.chattyNickname = nick
+                                player.sendFormattedMessage(nickMessage.selfSuccess)
                             }
                         }
                     }
@@ -144,97 +116,79 @@ class ChattyCommands : IdofrontCommandExecutor(), TabCompleter {
             }
             "commandspy" {
                 playerAction {
-                    (sender as? Player)?.toGeary()?.let {
-                        if (it.has<CommandSpy>()) {
-                            it.remove<CommandSpy>()
-                            player.sendFormattedMessage(chatty.messages.spying.commandSpyOff)
-                        } else {
-                            it.getOrSetPersisting { CommandSpy() }
-                            player.sendFormattedMessage(chatty.messages.spying.commandSpyOn)
-                        }
+                    val gearyPlayer = player.toGeary()
+                    if (gearyPlayer.has<CommandSpy>()) {
+                        gearyPlayer.remove<CommandSpy>()
+                        player.sendFormattedMessage(chatty.messages.spying.commandSpyOff)
+                    } else {
+                        gearyPlayer.getOrSetPersisting { CommandSpy() }
+                        player.sendFormattedMessage(chatty.messages.spying.commandSpyOn)
                     }
                 }
             }
             "spy" {
-                val channel by stringArg()
-                ensureSenderIsPlayer()
-                action {
-                    val player = sender as? Player ?: return@action
+                val channelName by stringArg()
+                playerAction {
+                    val channel = chatty.config.channels[channelName] ?: run {
+                        player.sendFormattedMessage(chatty.messages.channels.noChannelWithName)
+                        return@playerAction
+                    }
                     val spy = player.toGeary().getOrSetPersisting { SpyOnChannels() }
 
                     when {
-                        channel !in chatty.config.channels.keys ->
-                            player.sendFormattedMessage(chatty.messages.channels.noChannelWithName)
-
-                        getChannelFromId(channel)?.channelType == ChannelType.GLOBAL ->
+                        channel.channelType == ChannelType.GLOBAL ->
                             player.sendFormattedMessage(chatty.messages.spying.cannotSpyOnChannel)
 
-                        !player.hasPermission(getChannelFromId(channel)?.permission.toString()) ->
+                        !player.hasPermission(channel.permission) ->
                             player.sendFormattedMessage(chatty.messages.spying.cannotSpyOnChannel)
 
-                        channel in spy.channels -> {
+                        channel.key in spy.channels -> {
                             player.sendFormattedMessage(chatty.messages.spying.stopSpyingOnChannel)
-                            spy.channels.remove(channel)
+                            spy.channels.remove(channel.key)
                         }
 
                         else -> {
-                            spy.channels.add(channel)
+                            spy.channels.add(channel.key)
                             player.sendFormattedMessage(chatty.messages.spying.startSpyingOnChannel)
                         }
                     }
                 }
             }
-            getAllChannelNames().forEach { channelName ->
-                channelName {
-                    ensureSenderIsPlayer()
-                    action {
-                        val player = sender as? Player ?: return@action
-                        player.swapChannelCommand(channelName)
-                    }
-                }
-            }
-            chatty.config.channels.forEach { (channelId, channel) ->
-                channel.channelAliases.forEach { alias ->
-                    alias {
-                        ensureSenderIsPlayer()
-                        action {
-                            val player = sender as? Player ?: return@action
-                            player.swapChannelCommand(channelId)
+            chatty.config.channels.values
+                .flatMap { it.channelAliases + it.key }
+                .forEach { channelName ->
+                    channelName {
+                        playerAction {
+                            player.swapChannelCommand(chatty.config.channels[channelName])
                         }
                     }
                 }
-            }
         }
         ("global" / "g") {
-            ensureSenderIsPlayer()
-            action {
-                (sender as? Player)?.shortcutCommand(getGlobalChat(), arguments)
+            playerAction {
+                player.shortcutCommand(getGlobalChat(), arguments)
             }
         }
         ("local" / "l") {
-            ensureSenderIsPlayer()
-            action {
-                (sender as? Player)?.shortcutCommand(getRadiusChannel(), arguments)
+            playerAction {
+                player.shortcutCommand(getRadiusChannel(), arguments)
             }
         }
         ("admin" / "a") {
-            ensureSenderIsPlayer()
-            action {
-                (sender as? Player)?.shortcutCommand(getAdminChannel(), arguments)
+            playerAction {
+                player.shortcutCommand(getAdminChannel(), arguments)
             }
         }
         ("message" / "msg")(desc = "Private message another player") {
-            ensureSenderIsPlayer()
-            val player by stringArg()
-            action {
-                (sender as? Player)?.handleSendingPrivateMessage(player.toPlayer() ?: return@action, arguments, false)
+            val otherPlayer by stringArg()
+            playerAction {
+                player.handleSendingPrivateMessage(otherPlayer.toPlayer() ?: return@playerAction, arguments, false)
             }
         }
         ("reply" / "r")(desc = "Reply to your previous private message") {
-            ensureSenderIsPlayer()
-            action {
-                val player = sender as? Player ?: return@action
-                player.chattyData.lastMessager?.toPlayer()?.let { player.handleSendingPrivateMessage(it, arguments, true) }
+            playerAction {
+                player.toGeary().get<ChannelData>()?.lastMessager?.toPlayer()
+                    ?.let { player.handleSendingPrivateMessage(it, arguments, true) }
                     ?: player.sendFormattedMessage(chatty.messages.privateMessages.emptyReply)
             }
         }
@@ -250,44 +204,61 @@ class ChattyCommands : IdofrontCommandExecutor(), TabCompleter {
         val otherPrefix = chatty.config.nicknames.nickNameOtherPrefix
         return if (command.name == "chatty") {
             when (args.size) {
-                1 -> listOf("message", "ping", "reload", "channels", "nickname", "spy", "commandspy").filter { s -> s.startsWith(args[0]) }
+                1 -> listOf(
+                    "message",
+                    "ping",
+                    "reload",
+                    "channels",
+                    "nickname",
+                    "spy",
+                    "commandspy"
+                ).filter { s -> s.startsWith(args[0]) }
+
                 2 -> when (args[0]) {
                     "ping" -> listOf("toggle", "sound").filter { s -> s.startsWith(args[1]) }
                     "message", "msg" -> onlinePlayers.filter { s -> s.startsWith(args[1], true) }
                     "spy" ->
-                        chatty.config.channels.keys.toList().filter { s ->
-                            s.startsWith(args[1], true) && getChannelFromId(s)?.channelType != ChannelType.GLOBAL
-                        }
+                        chatty.config.channels.entries.filter { s ->
+                            s.key.startsWith(args[1], true) && s.value.channelType != ChannelType.GLOBAL
+                        }.map { it.key }
+
                     else -> emptyList()
                 }
+
                 3 -> when {
                     args[1] == "sound" -> getAlternativePingSounds.filter { s -> s.startsWith(args[2], true) }
                     args[1].startsWith(otherPrefix) -> onlinePlayers.filter { s ->
                         s.replace(otherPrefix.toString(), "").startsWith(args[2], true)
                     }
+
                     else -> emptyList()
                 }
+
                 else -> emptyList()
             }
         } else emptyList()
     }
 
     private fun Player.shortcutCommand(
-        channel: Map.Entry<String, ChattyConfig.ChattyChannel>?,
+        channel: Map.Entry<String, ChattyChannel>?,
         arguments: List<String>
     ) {
+        val chattyData = toGeary().get<ChannelData>() ?: return
         val currentChannel = chattyData.channelId
         when {
             channel == null -> sendFormattedMessage(chatty.messages.channels.noChannelWithName)
             channel.value.permission.isNotBlank() && !hasPermission(channel.value.permission) ->
                 sendFormattedMessage(chatty.messages.channels.missingChannelPermission)
 
-            arguments.isEmpty() -> swapChannelCommand(channel.key)
+            arguments.isEmpty() -> swapChannelCommand(channel.value)
             else -> {
-                toGeary().setPersisting(chattyData.copy(channelId = channel.key, lastChannelUsed = channel.key))
+                toGeary().setPersisting(chattyData.copy(channelId = channel.key, lastChannelUsedId = channel.key))
                 chatty.plugin.launch(chatty.plugin.asyncDispatcher) {
                     GenericChattyDecorateEvent(this@shortcutCommand, arguments.toSentence().miniMsg()).call {
-                        GenericChattyChatEvent(this@shortcutCommand, (this as AsyncChatDecorateEvent).result()).callEvent()
+                        GenericChattyChatEvent(
+                            this@shortcutCommand,
+                            (this as AsyncChatDecorateEvent).result()
+                        ).callEvent()
                     }
                 }
                 toGeary().setPersisting(chattyData.copy(channelId = currentChannel))
@@ -296,23 +267,24 @@ class ChattyCommands : IdofrontCommandExecutor(), TabCompleter {
     }
 
     private val replyMap = mutableMapOf<Player, Job>()
-    private fun handleReplyTimer(player: Player): Job {
-        if (player in replyMap) return replyMap[player]!!
+    private fun handleReplyTimer(player: Player, chattyData: ChannelData): Job {
+        replyMap[player]?.let { return it }
         replyMap[player]?.cancel()
-        return chatty.plugin.launch(chatty.plugin.asyncDispatcher) {
+        return chatty.plugin.launch {
             delay(chatty.config.privateMessages.messageReplyTime)
             replyMap[player]?.cancel()
             replyMap.remove(player)
-            player.toGeary().setPersisting(player.chattyData.copy(lastMessager = null))
+            player.toGeary().setPersisting(chattyData.copy(lastMessager = null))
         }
     }
 
-    private fun Player.handleSendingPrivateMessage(player: Player, arguments: List<String>, isReply: Boolean = false) {
+    private fun Player.handleSendingPrivateMessage(other: Player, arguments: List<String>, isReply: Boolean = false) {
+        val chattyData = toGeary().get<ChannelData>() ?: return
         when {
             !chatty.config.privateMessages.enabled ->
                 sendFormattedMessage(chatty.messages.privateMessages.disabled)
 
-            isReply && this.chattyData.lastMessager == null ->
+            isReply && chattyData.lastMessager == null ->
                 sendFormattedMessage(chatty.messages.privateMessages.emptyReply)
 
             !isReply && arguments.first().toPlayer() == null ->
@@ -320,17 +292,21 @@ class ChattyCommands : IdofrontCommandExecutor(), TabCompleter {
 
             else -> {
                 val msg = if (isReply) arguments.toSentence() else arguments.removeFirstArgumentOfStringList()
-                if (msg.isEmpty() || this == player) return
+                if (msg.isEmpty() || this == other) return
 
-                replyMap[player] = handleReplyTimer(player)
+                replyMap[other] = handleReplyTimer(other, chattyData)
 
-                this.sendFormattedPrivateMessage(chatty.config.privateMessages.messageSendFormat, msg, player)
-                player.sendFormattedPrivateMessage(chatty.config.privateMessages.messageReceiveFormat, msg, this)
-                player.toGeary().setPersisting(player.chattyData.copy(lastMessager = uniqueId))
+                this.sendFormattedPrivateMessage(chatty.config.privateMessages.messageSendFormat, msg, other)
+                other.sendFormattedPrivateMessage(chatty.config.privateMessages.messageReceiveFormat, msg, this)
+                val gearyOther = other.toGeary()
+                val otherChannelData = gearyOther.get<ChannelData>()
+                if (otherChannelData != null) {
+                    gearyOther.setPersisting(otherChannelData.copy(lastMessager = uniqueId))
+                }
                 if (chatty.config.privateMessages.messageSendSound.isNotEmpty())
-                    this.playSound(player.location, chatty.config.privateMessages.messageSendSound, 1f, 1f)
+                    this.playSound(other.location, chatty.config.privateMessages.messageSendSound, 1f, 1f)
                 if (chatty.config.privateMessages.messageReceivedSound.isNotEmpty())
-                    player.playSound(player.location, chatty.config.privateMessages.messageReceivedSound, 1f, 1f)
+                    other.playSound(other.location, chatty.config.privateMessages.messageReceivedSound, 1f, 1f)
             }
         }
     }
@@ -339,10 +315,31 @@ class ChattyCommands : IdofrontCommandExecutor(), TabCompleter {
         this.sendMessage(translatePlaceholders((optionalPlayer ?: this), message).parseTags(this, true))
 
     private fun Player.sendFormattedPrivateMessage(messageFormat: String, message: String, receiver: Player) =
-        this.sendMessage((translatePlaceholders(receiver, messageFormat).serialize() + message).parseTags(receiver, true))
+        this.sendMessage(
+            (translatePlaceholders(receiver, messageFormat).serialize() + message)
+                .parseTags(receiver, true)
+        )
 
     private fun CommandSender.sendConsoleMessage(message: String) = this.sendMessage(message.parseTags(null, true))
 
     private fun List<String>.removeFirstArgumentOfStringList(): String =
         this.filter { it != this.first() }.toSentence()
+
+
+    private fun Player.swapChannelCommand(newChannel: ChattyChannel?) {
+        when {
+            newChannel == null ->
+                sendFormattedMessage(chatty.messages.channels.noChannelWithName)
+
+            newChannel.permission.isNotBlank() && !hasPermission(newChannel.permission) ->
+                sendFormattedMessage(chatty.messages.channels.missingChannelPermission)
+
+            else -> {
+                val chattyData = toGeary().get<ChannelData>() ?: return
+                toGeary().setPersisting(chattyData.copy(channelId = newChannel.key, lastChannelUsedId = newChannel.key))
+                sendFormattedMessage(chatty.messages.channels.channelChanged)
+            }
+        }
+    }
+
 }

--- a/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/ChattyConfig.kt
+++ b/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/ChattyConfig.kt
@@ -2,10 +2,7 @@ package com.mineinabyss.chatty
 
 import com.mineinabyss.chatty.components.ChannelType
 import com.mineinabyss.idofront.serialization.DurationSerializer
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import net.kyori.adventure.text.format.NamedTextColor
-import net.kyori.adventure.text.format.TextColor
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 
@@ -71,26 +68,6 @@ data class ChattyConfig(
         val discordSrvChannelID: String = "Global",
         val sendProxyMessagesToDiscord: Boolean = true,
     )
-
-    @Serializable
-    data class ChattyChannel(
-        val channelType: ChannelType,
-        val permission: String = "",
-        val logToConsole: Boolean = true,
-        val simpleConsoleMessages: Boolean = false,
-        val proxy: Boolean = false,
-        val discordsrv: Boolean = true,
-        val isDefaultChannel: Boolean = false,
-        val isStaffChannel: Boolean = false,
-        val format: String = "",
-        @SerialName("messageColor") val _messageColor: String = "white",
-        val channelRadius: Int = 0,
-        val channelAliases: List<String> = listOf(),
-    ) {
-        val messageColor: TextColor
-            get() = TextColor.fromHexString(_messageColor) ?: NamedTextColor.NAMES.value(_messageColor)
-            ?: NamedTextColor.WHITE
-    }
 
     @Serializable
     data class Ping(

--- a/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/ChattyContext.kt
+++ b/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/ChattyContext.kt
@@ -1,6 +1,7 @@
 package com.mineinabyss.chatty
 
 import com.mineinabyss.chatty.helpers.DiscordEmoteFixer
+import com.mineinabyss.chatty.queries.SpyingPlayers
 import com.mineinabyss.idofront.config.IdofrontConfig
 import com.mineinabyss.idofront.di.DI
 import org.bukkit.Bukkit
@@ -14,4 +15,5 @@ interface ChattyContext {
     val emotefixer: DiscordEmoteFixer
     val isPlaceholderApiLoaded: Boolean
     val isDiscordSRVLoaded: Boolean
+    val spyingPlayers: SpyingPlayers
 }

--- a/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/ChattyPlugin.kt
+++ b/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/ChattyPlugin.kt
@@ -1,5 +1,8 @@
 package com.mineinabyss.chatty
 
+import com.mineinabyss.chatty.components.ChannelData
+import com.mineinabyss.chatty.components.ChattyNickname
+import com.mineinabyss.chatty.components.CommandSpy
 import com.mineinabyss.chatty.helpers.DiscordEmoteFixer
 import com.mineinabyss.chatty.listeners.ChatListener
 import com.mineinabyss.chatty.listeners.ChattyProxyListener
@@ -7,6 +10,7 @@ import com.mineinabyss.chatty.listeners.DiscordListener
 import com.mineinabyss.chatty.listeners.PlayerListener
 import com.mineinabyss.chatty.placeholders.PlaceholderAPIHook
 import com.mineinabyss.geary.autoscan.autoscan
+import com.mineinabyss.geary.helpers.componentId
 import com.mineinabyss.geary.modules.geary
 import com.mineinabyss.idofront.config.config
 import com.mineinabyss.idofront.di.DI
@@ -40,6 +44,10 @@ class ChattyPlugin : JavaPlugin() {
 
         if (chatty.isDiscordSRVLoaded)
             DiscordSRV.api.subscribe(DiscordListener())
+
+        // register components we'll use async now since they'll error otherwise
+        componentId<ChattyNickname>()
+        componentId<ChannelData>()
     }
 
     fun createChattyContext() {

--- a/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/ChattyPlugin.kt
+++ b/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/ChattyPlugin.kt
@@ -9,6 +9,7 @@ import com.mineinabyss.chatty.listeners.ChattyProxyListener
 import com.mineinabyss.chatty.listeners.DiscordListener
 import com.mineinabyss.chatty.listeners.PlayerListener
 import com.mineinabyss.chatty.placeholders.PlaceholderAPIHook
+import com.mineinabyss.chatty.queries.SpyingPlayers
 import com.mineinabyss.geary.autoscan.autoscan
 import com.mineinabyss.geary.helpers.componentId
 import com.mineinabyss.geary.modules.geary
@@ -59,6 +60,9 @@ class ChattyPlugin : JavaPlugin() {
             override val emotefixer: DiscordEmoteFixer by config("emotefixer", dataFolder.toPath(), DiscordEmoteFixer())
             override val isPlaceholderApiLoaded: Boolean = Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")
             override val isDiscordSRVLoaded: Boolean = Bukkit.getPluginManager().isPluginEnabled("DiscordSRV")
+            override val spyingPlayers: SpyingPlayers = SpyingPlayers().apply {
+                registerIfNotRegistered()
+            }
         }
 
         DI.add<ChattyContext>(chattyContext)

--- a/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/ChattyPlugin.kt
+++ b/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/ChattyPlugin.kt
@@ -27,6 +27,10 @@ class ChattyPlugin : JavaPlugin() {
                 all()
             }
         }
+
+        // register components we'll use async now since they'll error otherwise
+        componentId<ChattyNickname>()
+        componentId<ChannelData>()
     }
 
     override fun onEnable() {
@@ -39,16 +43,11 @@ class ChattyPlugin : JavaPlugin() {
 
         ChattyCommands()
         listeners(ChatListener(), PlayerListener())
-
         if (chatty.isPlaceholderApiLoaded)
             PlaceholderAPIHook().register()
 
         if (chatty.isDiscordSRVLoaded)
             DiscordSRV.api.subscribe(DiscordListener())
-
-        // register components we'll use async now since they'll error otherwise
-        componentId<ChattyNickname>()
-        componentId<ChannelData>()
     }
 
     fun createChattyContext() {

--- a/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/components/ChannelData.kt
+++ b/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/components/ChannelData.kt
@@ -12,7 +12,6 @@ import java.util.*
 @SerialName("chatty:chatty_data")
 data class ChannelData(
     val channelId: String = getDefaultChat().key,
-    @SerialName("lastChannelUsed")
     val lastChannelUsedId: String = channelId,
     val disablePingSound: Boolean = false,
     val pingSound: String? = null,

--- a/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/components/ChannelData.kt
+++ b/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/components/ChannelData.kt
@@ -1,24 +1,35 @@
 package com.mineinabyss.chatty.components
 
+import com.mineinabyss.chatty.ChattyChannel
+import com.mineinabyss.chatty.chatty
 import com.mineinabyss.chatty.helpers.getDefaultChat
-import com.mineinabyss.geary.papermc.tracking.entities.toGeary
 import com.mineinabyss.idofront.serialization.UUIDSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import org.bukkit.entity.Player
 import java.util.*
 
 @Serializable
 @SerialName("chatty:chatty_data")
 data class ChannelData(
     val channelId: String = getDefaultChat().key,
-    val lastChannelUsed: String = channelId,
+    @SerialName("lastChannelUsed")
+    val lastChannelUsedId: String = channelId,
     val disablePingSound: Boolean = false,
     val pingSound: String? = null,
     val lastMessager: @Serializable(UUIDSerializer::class) UUID? = null,
-)
+) {
+    val channel: ChattyChannel? get() = chatty.config.channels[channelId]
+    val lastChannelUsed: ChattyChannel? get() = chatty.config.channels[lastChannelUsedId]
 
-val Player.chattyData get() =  toGeary().getOrSetPersisting { ChannelData() }
+    fun withChannelVerified(): ChannelData {
+        if (channelId !in chatty.config.channels)
+            return copy(channelId = getDefaultChat().key)
+        return this
+    }
+}
+
+//val Player.chattyData get() =  toGeary().getOrSetPersisting { ChannelData() }
+
 enum class ChannelType {
     GLOBAL,
     RADIUS,

--- a/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/listeners/ChatListener.kt
+++ b/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/listeners/ChatListener.kt
@@ -1,18 +1,20 @@
 package com.mineinabyss.chatty.listeners
 
-import com.mineinabyss.chatty.ChattyConfig
+import com.github.shynixn.mccoroutine.bukkit.launch
+import com.mineinabyss.chatty.ChattyChannel
 import com.mineinabyss.chatty.chatty
 import com.mineinabyss.chatty.chattyProxyChannel
 import com.mineinabyss.chatty.components.*
 import com.mineinabyss.chatty.helpers.*
-import com.mineinabyss.geary.papermc.tracking.entities.toGeary
+import com.mineinabyss.geary.datatypes.family.family
+import com.mineinabyss.geary.papermc.tracking.entities.toGearyOrNull
+import com.mineinabyss.geary.systems.accessors.Pointer
+import com.mineinabyss.geary.systems.query.GearyQuery
 import com.mineinabyss.idofront.textcomponents.miniMsg
 import com.mineinabyss.idofront.textcomponents.serialize
-import io.papermc.paper.chat.ChatRenderer
 import io.papermc.paper.event.player.AsyncChatCommandDecorateEvent
 import io.papermc.paper.event.player.AsyncChatDecorateEvent
 import io.papermc.paper.event.player.AsyncChatEvent
-import net.kyori.adventure.audience.Audience
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.minimessage.MiniMessage
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer
@@ -22,17 +24,23 @@ import org.bukkit.event.EventHandler
 import org.bukkit.event.EventPriority
 import org.bukkit.event.Listener
 import org.bukkit.event.player.PlayerCommandPreprocessEvent
-import kotlin.math.sqrt
 
 @Suppress("UnstableApiUsage")
 class ChatListener : Listener {
     val plainText = PlainTextComponentSerializer.plainText()
+    val commandSpyQuery = CommandSpyQuery()
+
+    class CommandSpyQuery : GearyQuery() {
+        val Pointer.player by get<Player>()
+        val Pointer.commandSpy by family { has<CommandSpy>() }
+    }
 
     @EventHandler
     fun PlayerCommandPreprocessEvent.onPlayerCommand() {
-        Bukkit.getOnlinePlayers().filter { it.uniqueId != player.uniqueId && it.toGeary().has<CommandSpy>() }.forEach { p ->
-            p.sendFormattedMessage(chatty.config.chat.commandSpyFormat, message, optionalPlayer = player)
-        }
+        commandSpyQuery.run { toList { it.player } }
+            .forEach { p ->
+                p.sendFormattedMessage(chatty.config.chat.commandSpyFormat, message, optionalPlayer = player)
+            }
     }
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
@@ -47,17 +55,20 @@ class ChatListener : Listener {
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     fun AsyncChatEvent.onPlayerChat() {
-        player.verifyPlayerChannel()
-        val channelId = player.chattyData.channelId
-        val channel = getChannelFromId(channelId) ?: return
+        val ogChannelData = player.toGearyOrNull()?.get<ChannelData>() ?: return
+        val channelData = ogChannelData.withChannelVerified()
+        val channelId = channelData.channelId
+        val channel = channelData.channel ?: return
 
         if (viewers().isNotEmpty()) viewers().clear()
-        viewers() += setAudienceForChannelType(player)
+        viewers() += channel.getAudience(player)
 
         val pingedPlayer = originalMessage().serialize().checkForPlayerPings(channelId)
         if (pingedPlayer != null && pingedPlayer != player && pingedPlayer in viewers()) {
-            message().handlePlayerPings(player, pingedPlayer)
             viewers() -= setOf(pingedPlayer, player)
+            val pingedChannelData = pingedPlayer.toGearyOrNull()?.get<ChannelData>()
+            if (pingedChannelData != null)
+                message().handlePlayerPings(player, pingedPlayer, pingedChannelData)
         }
 
         if (channel.proxy) {
@@ -89,44 +100,16 @@ class ChatListener : Listener {
         } else renderer { _, _, _, _ -> return@renderer message() }
     }
 
-    private fun setAudienceForChannelType(player: Player): Set<Audience> {
-        val onlinePlayers = Bukkit.getOnlinePlayers()
-        val channel = getChannelFromId(player.chattyData.channelId) ?: return emptySet()
-        val audiences = mutableSetOf<Audience>()
-
-        when (channel.channelType) {
-            ChannelType.GLOBAL -> audiences.addAll(onlinePlayers)
-            ChannelType.RADIUS -> {
-                if (channel.channelRadius <= 0) audiences.addAll(onlinePlayers)
-                else audiences.addAll(onlinePlayers.filter { p ->
-                    player.world == p.world && sqrt(player.location.distanceSquared(p.location)) <= channel.channelRadius
-                })
-            }
-
-            ChannelType.PERMISSION ->
-                audiences.addAll(onlinePlayers.filter { p -> p.hasPermission(channel.permission) })
-            // Intended for Guilds etc., want to consider finding a non-permission way for this
-            ChannelType.PRIVATE -> audiences.add(player)
-        }
-
-        audiences.addAll(onlinePlayers.filter { p ->
-            p !in audiences && p.toGeary().get<SpyOnChannels>()?.channels?.contains(player.chattyData.channelId) == true
-        })
-
-        return audiences
-    }
-
     private fun Player.sendFormattedMessage(vararg message: String, optionalPlayer: Player? = null) =
-        this.sendMessage(translatePlaceholders((optionalPlayer ?: this), message.joinToString(" ")).parseTags(optionalPlayer ?: this, true))
+        this.sendMessage(
+            translatePlaceholders((optionalPlayer ?: this), message.joinToString(" ")).parseTags(
+                optionalPlayer ?: this,
+                true
+            )
+        )
 
-    private fun Component.stripMessageFormat(player: Player, channel: ChattyConfig.ChattyChannel) =
+    private fun Component.stripMessageFormat(player: Player, channel: ChattyChannel) =
         plainText.serialize(this)
-            .replace(plainText.serialize(translatePlaceholders(player, channel.format).parseTags(player, true)), "").miniMsg().parseTags(player, false)
-}
-
-object RendererExtension : ChatRenderer {
-    override fun render(source: Player, sourceDisplayName: Component, message: Component, viewer: Audience): Component {
-
-        return message
-    }
+            .replace(plainText.serialize(translatePlaceholders(player, channel.format).parseTags(player, true)), "")
+            .miniMsg().parseTags(player, false)
 }

--- a/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/listeners/ChatListener.kt
+++ b/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/listeners/ChatListener.kt
@@ -66,9 +66,9 @@ class ChatListener : Listener {
         val pingedPlayer = originalMessage().serialize().checkForPlayerPings(channelId)
         if (pingedPlayer != null && pingedPlayer != player && pingedPlayer in viewers()) {
             viewers() -= setOf(pingedPlayer, player)
-            val pingedChannelData = pingedPlayer.toGearyOrNull()?.get<ChannelData>()
-            if (pingedChannelData != null)
+            pingedPlayer.toGearyOrNull()?.get<ChannelData>()?.let { pingedChannelData ->
                 message().handlePlayerPings(player, pingedPlayer, pingedChannelData)
+            }
         }
 
         if (channel.proxy) {

--- a/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/listeners/ChattyProxyListener.kt
+++ b/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/listeners/ChattyProxyListener.kt
@@ -36,7 +36,7 @@ class ChattyProxyListener : PluginMessageListener {
         val proxyMessage = decoded.substringAfterLast(ZERO_WIDTH)
 
         val onlinePlayers = Bukkit.getOnlinePlayers().filter { it.server == Bukkit.getServer() }
-        val canSpy = SpyingPlayers().run {
+        val canSpy = chatty.spyingPlayers.run {
             toList { query -> query.player.takeIf { query.spying.channels.contains(channelId) } }
                 .filterNotNull()
         }

--- a/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/listeners/ChattyProxyListener.kt
+++ b/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/listeners/ChattyProxyListener.kt
@@ -1,14 +1,13 @@
 package com.mineinabyss.chatty.listeners
 
+import com.mineinabyss.chatty.ChattyChannel
 import com.mineinabyss.chatty.chatty
 import com.mineinabyss.chatty.chattyProxyChannel
+import com.mineinabyss.chatty.components.ChannelData
 import com.mineinabyss.chatty.components.ChannelType
-import com.mineinabyss.chatty.components.SpyOnChannels
-import com.mineinabyss.chatty.components.chattyData
 import com.mineinabyss.chatty.helpers.ZERO_WIDTH
-import com.mineinabyss.chatty.helpers.getChannelFromId
-import com.mineinabyss.chatty.helpers.getChannelFromPlayer
 import com.mineinabyss.chatty.helpers.toPlayer
+import com.mineinabyss.chatty.queries.SpyingPlayers
 import com.mineinabyss.geary.papermc.tracking.entities.toGeary
 import com.mineinabyss.idofront.textcomponents.miniMsg
 import github.scarsz.discordsrv.Debug
@@ -33,12 +32,13 @@ class ChattyProxyListener : PluginMessageListener {
         val senderName = decoded.substringBefore(ZERO_WIDTH)
         val channelId = decoded.substringAfter(ZERO_WIDTH).split(ZERO_WIDTH).first()
         val channelFormat = decoded.substringAfter(channelId + ZERO_WIDTH).split(ZERO_WIDTH).first()
-        val channel = getChannelFromId(channelId)
+        val channel = chatty.config.channels[channelId]
         val proxyMessage = decoded.substringAfterLast(ZERO_WIDTH)
 
         val onlinePlayers = Bukkit.getOnlinePlayers().filter { it.server == Bukkit.getServer() }
-        val canSpy = onlinePlayers.filter {
-            it.toGeary().get<SpyOnChannels>()?.channels?.contains(player.chattyData.channelId) == true
+        val canSpy = SpyingPlayers().run {
+            toList { query -> query.player.takeIf { query.spying.channels.contains(channelId) } }
+                .filterNotNull()
         }
 
         // If the channel is not found, it is discord
@@ -50,46 +50,67 @@ class ChattyProxyListener : PluginMessageListener {
                 ChannelType.GLOBAL -> onlinePlayers
                 ChannelType.RADIUS -> canSpy
                 ChannelType.PERMISSION -> onlinePlayers.filter { it.hasPermission(channel.permission) || it in canSpy }
-                ChannelType.PRIVATE -> onlinePlayers.filter { it.getChannelFromPlayer() == channel || it in canSpy }
+                ChannelType.PRIVATE -> onlinePlayers.filter {
+                    it.toGeary().get<ChannelData>()?.channel == channel || it in canSpy
+                }
             }.forEach { it.sendMessage(proxyMessage.miniMsg()) }
         }
 
 
-        if (!chatty.config.proxy.sendProxyMessagesToDiscord ||
-            channel?.discordsrv != true || !chatty.isDiscordSRVLoaded
-        ) return
+        if (chatty.config.proxy.sendProxyMessagesToDiscord
+            && channel?.discordsrv == true
+            && chatty.isDiscordSRVLoaded
+        ) {
+            sendToDiscord(proxyMessage, senderName, channel, channelFormat)
+        }
 
+    }
+
+    fun sendToDiscord(proxyMessage: String, senderName: String, channel: ChattyChannel, channelFormat: String) {
         val reserializer = DiscordSRV.config().getBoolean("Experiment_MCDiscordReserializer_ToDiscord")
-        val discordChannel = DiscordSRV.getPlugin().getDestinationTextChannelForGameChannelName(chatty.config.proxy.discordSrvChannelID)
+        val discordChannel = DiscordSRV.getPlugin()
+            .getDestinationTextChannelForGameChannelName(chatty.config.proxy.discordSrvChannelID)
 
         when {
             discordChannel == null -> {
-                DiscordSRV.debug(Debug.MINECRAFT_TO_DISCORD,
-                    "Failed to find Discord channel to forward message from game channel $channel")
+                DiscordSRV.debug(
+                    Debug.MINECRAFT_TO_DISCORD,
+                    "Failed to find Discord channel to forward message from game channel $channel"
+                )
             }
+
             !DiscordUtil.checkPermission(discordChannel.guild, Permission.MANAGE_WEBHOOKS) ->
                 DiscordSRV.error("Couldn't deliver chat message as webhook because the bot lacks the \"Manage Webhooks\" permission.")
+
             else -> {
                 val discordMessage = proxyMessage.replaceFirst(channelFormat, "")
                     .apply { PlaceholderUtil.replacePlaceholdersToDiscord(this) }
                     .apply { if (!reserializer) MessageUtil.strip(this) }
-                    .apply { if (translateMentions) DiscordUtil.convertMentionsFromNames(this, DiscordSRV.getPlugin().mainGuild) }
+                    .apply {
+                        if (translateMentions) DiscordUtil.convertMentionsFromNames(
+                            this,
+                            DiscordSRV.getPlugin().mainGuild
+                        )
+                    }
 
                 val whUsername = DiscordSRV.config().getString("Experiment_WebhookChatMessageUsernameFormat")
                     .replace("(%displayname%)|(%username%)".toRegex(), senderName)
                     .let { MessageUtil.strip(PlaceholderUtil.replacePlaceholders(it)) }
 
-                WebhookUtil.deliverMessage(discordChannel, whUsername,
+                WebhookUtil.deliverMessage(
+                    discordChannel, whUsername,
                     DiscordSRV.getAvatarUrl(senderName, senderName.toPlayer()?.uniqueId),
                     discordMessage.translateEmoteIDsToComponent(),
                     MessageEmbed(null, null, null, null, null, 10, null, null, null, null, null, null, null)
                 )
             }
         }
+
     }
 
     private val translateMentions =
         if (!chatty.isDiscordSRVLoaded) false else DiscordSRV.config().getBoolean("DiscordChatChannelTranslateMentions")
+
     private fun String.translateEmoteIDsToComponent(): String {
         var translated = this
         chatty.emotefixer.emotes.entries.forEach { (emoteId, replacement) ->

--- a/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/listeners/PlayerListener.kt
+++ b/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/listeners/PlayerListener.kt
@@ -3,10 +3,7 @@ package com.mineinabyss.chatty.listeners
 import com.mineinabyss.chatty.chatty
 import com.mineinabyss.chatty.components.ChannelData
 import com.mineinabyss.chatty.components.HideJoinLeave
-import com.mineinabyss.chatty.helpers.parseTags
-import com.mineinabyss.chatty.helpers.refreshSkinInCaches
-import com.mineinabyss.chatty.helpers.translatePlaceholders
-import com.mineinabyss.chatty.helpers.verifyPlayerChannel
+import com.mineinabyss.chatty.helpers.*
 import com.mineinabyss.geary.papermc.tracking.entities.toGeary
 import com.mineinabyss.idofront.textcomponents.serialize
 import org.bukkit.event.EventHandler
@@ -29,8 +26,9 @@ class PlayerListener : Listener {
 
     @EventHandler(priority = EventPriority.NORMAL)
     fun PlayerJoinEvent.onJoin() {
-        player.verifyPlayerChannel()
-        if (chatty.config.join.enabled && !player.toGeary().has<HideJoinLeave>())
+        val gearyPlayer = player.toGeary()
+        gearyPlayer.getOrSetPersisting { ChannelData() }
+        if (chatty.config.join.enabled && !gearyPlayer.has<HideJoinLeave>())
             joinMessage(translatePlaceholders(player, chatty.messages.joinLeave.joinMessage))
     }
 

--- a/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/queries/SpyingPlayers.kt
+++ b/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/queries/SpyingPlayers.kt
@@ -1,0 +1,13 @@
+package com.mineinabyss.chatty.queries
+
+import com.mineinabyss.chatty.components.CommandSpy
+import com.mineinabyss.chatty.components.SpyOnChannels
+import com.mineinabyss.geary.datatypes.family.family
+import com.mineinabyss.geary.systems.accessors.Pointer
+import com.mineinabyss.geary.systems.query.GearyQuery
+import org.bukkit.entity.Player
+
+class SpyingPlayers: GearyQuery() {
+    val Pointer.player by get<Player>()
+    val Pointer.spying by get<SpyOnChannels>()
+}

--- a/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/tags/ChattyTags.kt
+++ b/chatty-paper/src/main/kotlin/com/mineinabyss/chatty/tags/ChattyTags.kt
@@ -14,9 +14,9 @@ import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver
 
 object ChattyTags {
 
-    private val SHIFT = "shift"
-    private val HEAD = "head"
-    private val SKIN = "skin"
+    private const val SHIFT = "shift"
+    private const val HEAD = "head"
+    private const val SKIN = "skin"
 
     val SHIFT_RESOLVER: TagResolver = SerializableResolver.claimingComponent(
         SHIFT, { args: ArgumentQueue, ctx: Context -> create(args, ctx, SHIFT) },

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.mineinabyss
 version=0.7
-idofrontVersion=0.20.6
+idofrontVersion=0.20.14
 velocityVersion=3.2.0
 coroutinesVersion=1.6.4


### PR DESCRIPTION
- Avoid any persistent set calls or entity creations in all async chat threads
- Some small cleanup around commands (ex add tab completion to msg, general cleanup)
- Add query for players with spy enabled to simplify some code
- Restructure code to be a bit more explicit to discourage accidental writes on async threads (ex. removed player.chattyData in favor of getting once and reusing)